### PR TITLE
Issue #6 [Emails] Store (and list) emails sent through the SMTP server

### DIFF
--- a/internal/models/mail_api_key.go
+++ b/internal/models/mail_api_key.go
@@ -22,6 +22,7 @@ type MailApiKey struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+	IsNewlyCreated bool
 }
 
 var _ bun.BeforeAppendModelHook = (*MailApiKey)(nil)

--- a/views/concerns/mails/pages/api_keys.templ
+++ b/views/concerns/mails/pages/api_keys.templ
@@ -28,6 +28,7 @@ templ APIKeysPage(mailDomains []models.MailDomain, apiKeys []models.MailApiKey) 
 			<h3 class="mt-2 text-zinc-300 text-sm">
 				API keys are used to access the Facteur API. You can create or revoke them at any time.
 			</h3>
+			<div id="new-api-key-result"></div>
 			<div class="mt-8 flow-root">
 				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
 					<div class="inline-block min-w-full py-2 align-middle px-4 sm:px-6 lg:px-8">
@@ -130,7 +131,7 @@ templ apiKeysTableItem(apiKey models.MailApiKey) {
 }
 
 templ addApiKeyDialog(mailDomains []models.MailDomain) {
-	<form hx-post={ "/orgs/" + ctx.Value(middleware.CTX_KEY_ORG_ID).(string) + "/mails/api_keys" }>
+	<form hx-post={ "/orgs/" + ctx.Value(middleware.CTX_KEY_ORG_ID).(string) + "/mails/api_keys" }hx-target="#new-api-key-result">
 		@ui.Dialog(ui.DialogProps{
 			Id:    "add_api_key",
 			Title: "Add API Key",
@@ -161,8 +162,21 @@ templ addApiKeyDialog(mailDomains []models.MailDomain) {
 					Add API Key
 				}
 			</div>
+			<div id="api-key-result"></div>
 		}
 	</form>
+}
+
+templ newApiKeyResult(apiKey models.MailApiKey) {
+    if apiKey.IsNewlyCreated {
+        <div class="mt-4 p-4 bg-yellow-100 border border-yellow-400 text-yellow-700 rounded">
+            <h4 class="font-bold">New API Key Created</h4>
+            <p class="mt-2">Your new API key is: <strong>{ apiKey }</strong></p>
+            <p class="mt-2 text-red-600 font-bold">
+                WARNING: Store this key securely. It will not be shown again. If lost, you'll need to create a new key.
+            </p>
+        </div>
+    }
 }
 
 func getSelectOptionsForMailDomains(mailDomains []models.MailDomain) []ui.SelectFieldOption {


### PR DESCRIPTION
Implemented bcrypt hash on creation, hash validation on input, and save option for apiKey after creation. Note: save option will need to be reconfigured to fit to the rest of the code as currently it is fmt.Print for testing.