### PR TITLE
 [Emails] Store (and list) emails sent through the SMTP server #6 

### DIFF
--- a/internal/models/email_sent.go
+++ b/internal/models/email_sent.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/xid"
+	"github.com/uptrace/bun"
+)
+
+type Email struct {
+	ID             string        `bun:"id,pk"`
+	Subject        string        `bun:"subject"`
+	Slug           string        `bun:"slug,unique"`
+	Organization   *Organization `bun:"rel:belongs-to,join:organization_id=id"`
+	OrganizationID string        `bun:"rel:organization_id"`
+	Sender         string        `bun:"sender"`
+	Recipient      string        `bun:"recipient"`
+	Body           string        `bun:"body"`
+	Inc_attach     bool          `bun:"incl_attach"`
+	Send_time      time.Time     `bun:"send_time"`
+	CreatedAt      time.Time     `bun:"created_at"`
+	UpdatedAt      time.Time     `bun:"updated_at"`
+}
+
+var _ bun.BeforeAppendModelHook = (*Deployment)(nil)
+
+func (e *Email) BeforeAppend(ctx context.Context, query bun.Query) error {
+	switch query.(type) {
+	case *bun.InsertQuery:
+		e.ID = xid.New().String()
+		e.CreatedAt = time.Now()
+	case *bun.UpdateQuery:
+		e.UpdatedAt = time.Now()
+	}
+	return nil
+}

--- a/internal/repositories/emails_repository.go
+++ b/internal/repositories/emails_repository.go
@@ -1,0 +1,66 @@
+package repositories
+
+import (
+	"citadel/internal/models"
+	"context"
+
+	"github.com/Squwid/go-randomizer"
+	"github.com/caesar-rocks/orm"
+	"github.com/gosimple/slug"
+)
+
+type EmailRepository struct {
+	*orm.Repository[models.Email]
+}
+
+func NewEmailRepository(db *orm.Database) *EmailRepository {
+	return &EmailRepository{Repository: &orm.Repository[models.Email]{Database: db}}
+}
+func (r EmailRepository) Create(ctx context.Context, e *models.Email) error {
+	slug := slug.Make(e.Subject)
+
+	for {
+		_, err := r.FindOneBy(ctx, "slug", slug)
+		if err != nil {
+			break
+		}
+
+		slug = slug + "-" + randomizer.Noun()
+	}
+	e.Slug = slug
+
+	_, err := r.NewInsert().Model(e).Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Retrieve emails from the database
+// This function allows the user to retrieve all emails, emails from a specific sender, and emails to a specific recipient
+// Limiting and offset have been implemented to provide efficiency and performance for querying the database
+func (r EmailRepository) FindEmails(ctx context.Context, orgID string, filter map[string]string, limit, offset int) ([]models.Email, error) {
+    var emails []models.Email
+    query := r.NewSelect().Model(&emails).Where("organization_id = ?", orgID)
+
+    // Apply filters
+    if sender, ok := filter["sender"]; ok && sender != "" {
+        query = query.Where("sender = ?", sender)
+    }
+    if recipient, ok := filter["recipient"]; ok && recipient != "" {
+        query = query.Where("recipient = ?", recipient)
+    }
+
+    // Apply sorting, limit, and offset
+    err := query.
+        Order("created_at DESC").
+        Limit(limit).
+        Offset(offset).
+        Scan(ctx)
+
+    if err != nil {
+        return nil, err
+    }
+    return emails, nil
+}

--- a/internal/smtp_backend/smtp_backend.go
+++ b/internal/smtp_backend/smtp_backend.go
@@ -6,17 +6,18 @@ import (
 	smtpSender "citadel/internal/smtp_sender"
 	"citadel/util"
 	"context"
+	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
-	"net/http"
 	"io"
+	"math/big"
+	"net/http"
 	"net/mail"
 	"os"
-	"time"
+	"strconv"
 	"strings"
-	"math/big"
-	"crypto/rand"
-	"encoding/json"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -31,14 +32,16 @@ import (
 type Backend struct {
 	apiKeysRepo *repositories.MailApiKeysRepository
 	domainsRepo *repositories.MailDomainsRepository
+	emailsRepo  *repositories.EmailRepository
 }
 
 // New creates a new Backend.
 func New(
 	apiKeysRepo *repositories.MailApiKeysRepository,
 	domainsRepo *repositories.MailDomainsRepository,
+	emailsRepo *repositories.EmailRepository,
 ) *Backend {
-	return &Backend{apiKeysRepo, domainsRepo}
+	return &Backend{apiKeysRepo, domainsRepo, emailsRepo}
 }
 
 // NewSession is called after client greeting (EHLO, HELO).
@@ -46,6 +49,7 @@ func (bkd *Backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 	return &Session{
 		apiKeysRepo: bkd.apiKeysRepo,
 		domainsRepo: bkd.domainsRepo,
+		emailsRepo:  bkd.emailsRepo,
 	}, nil
 }
 
@@ -53,11 +57,12 @@ func (bkd *Backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 type Session struct {
 	apiKeysRepo *repositories.MailApiKeysRepository
 	domainsRepo *repositories.MailDomainsRepository
+	emailsRepo  *repositories.EmailRepository
 
-	from   string
-	to     string
-	apiKey *models.MailApiKey
-	domain *models.MailDomain
+	from      string
+	to        string
+	apiKey    *models.MailApiKey
+	domain    *models.MailDomain
 	newAPIKey string
 }
 
@@ -88,12 +93,12 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 		}
 		//If the api wasn't found or didn't match, check if a new creation is needed
 		if password == "" {
-			//Generate a random password 
+			//Generate a random password
 			password, err = PasswordGenerator(32)
 			if err != nil {
 				return errors.New("failed to create random password")
 			}
-            // Hash the password for storage in the database
+			// Hash the password for storage in the database
 			newAPIKey, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 			if err != nil {
 				return errors.New("failed to create new API key")
@@ -128,6 +133,7 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 		return errors.New("invalid api key")
 	}), nil
 }
+
 // New function to determine if API key is new or not
 func (s *Session) GetNewAPIKeyInfo() (string, bool) {
 	if s.apiKey.IsNewlyCreated {
@@ -136,7 +142,8 @@ func (s *Session) GetNewAPIKeyInfo() (string, bool) {
 	}
 	return "", false
 }
-//Handle API Key Auth and update client side information
+
+// Handle API Key Auth and update client side information
 func HandleAuth(w http.ResponseWriter, r *http.Request) {
 	s := &Session{}
 	server, err := s.Auth("PLAIN")
@@ -147,20 +154,21 @@ func HandleAuth(w http.ResponseWriter, r *http.Request) {
 	log.Print(server)
 	// Check if a new API Key was created
 	newAPIKey, isNew := s.GetNewAPIKeyInfo()
-    if isNew {
-        // Return the new API key information as JSON
-        w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(map[string]string{
-            "status": "new_key_created",
-            "apiKey": newAPIKey,
-        })
-    } else {
-        w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(map[string]string{
-            "status": "authentication_successful",
-        })
-    }
+	if isNew {
+		// Return the new API key information as JSON
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"status": "new_key_created",
+			"apiKey": newAPIKey,
+		})
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"status": "authentication_successful",
+		})
+	}
 }
+
 // Generate a random Password
 func PasswordGenerator(length int) (string, error) {
 	const (
@@ -252,7 +260,82 @@ func (s *Session) Data(r io.Reader) error {
 	sender := smtpSender.New(os.Getenv("SMTP_DOMAIN"))
 	sender.Send(s.from, s.to, outputMsg)
 
+	// Set the email params for storing to the database
+	e := &models.Email{
+		Sender:         s.from,
+		Recipient:      s.to,
+		OrganizationID: s.domain.OrganizationID,
+		Subject:        msg.Header.Get("Subject"),
+		Body:           string(outputMsg),
+		CreatedAt:      (time.Now()),
+		UpdatedAt:      (time.Now()),
+	}
+	// Store the email in the database
+	err = s.emailsRepo.Create(context.Background(), e)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (s *Session) HandleListSentEmails(w http.ResponseWriter, r *http.Request) {
+	// Capture OrgID
+	orgID := s.domain.OrganizationID
+	if orgID == "" {
+		http.Error(w, "Organization ID is required", http.StatusBadRequest)
+		return
+	}
+
+	// Capture additionaly query inputs from user
+
+	filter := make(map[string]string)
+	if sender := r.URL.Query().Get("sender"); sender != "" {
+		filter["sender"] = sender
+	}
+	if recipient := r.URL.Query().Get("recipient"); recipient != "" {
+		filter["recipient"] = recipient
+	}
+
+	// Set return limit
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 {
+		limit = 20 // Default limit
+	}
+
+	// Set return offset
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Retrieve emails from the database
+	emails, err := s.ListSentEmails(r.Context(), orgID, filter, limit, offset)
+	if err != nil {
+		log.Error("Error retrieving emails", "error", err)
+		http.Error(w, "Failed to retrieve emails", http.StatusInternalServerError)
+		return
+	}
+	// Craft the response
+	response := struct {
+		Status string         `json:"status"`
+		Emails []models.Email `json:"emails"`
+	}{
+		Status: "success",
+		Emails: emails,
+	}
+	// Serve the response to the rendering page
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Error("Error encoding response", "error", err)
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+// Listener for retrieving emails
+func (s *Session) ListSentEmails(ctx context.Context, orgID string, filter map[string]string, limit, offset int) ([]models.Email, error) {
+	return s.emailsRepo.FindEmails(ctx, orgID, filter, limit, offset)
 }
 
 // Reset is called after RSET.

--- a/views/concerns/mails/components/tabs.templ
+++ b/views/concerns/mails/components/tabs.templ
@@ -11,7 +11,7 @@ templ Tabs() {
 			@ui.Tab(util.Route(ctx, "/mails"), "Overview")
 			@ui.Tab(util.Route(ctx, "/mails/domains"), "Domains")
 			@ui.Tab(util.Route(ctx, "/mails/api_keys"), "API Keys")
-			// @ui.Tab(util.Route(ctx, "/mails/emails"), "Emails")
+			@ui.Tab(util.Route(ctx, "/mails/emails"), "Emails")
 			// @ui.Tab(util.Route(ctx, "/mails/metrics"), "Metrics")
 		</ul>
 	</nav>

--- a/views/concerns/mails/pages/list_emails.templ
+++ b/views/concerns/mails/pages/list_emails.templ
@@ -1,0 +1,90 @@
+package mailsPages
+
+import (
+    "citadel/internal/models"
+    "citadel/views/layouts"
+    "citadel/views/ui"
+    "citadel/views/concerns/mails/components"
+    "citadel/views/util"
+    "time"
+)
+
+templ ListSentEmailsPage(emails []models.Email) {
+    @layouts.DashboardLayout(layouts.DashboardLayoutProps{Class: "!p-0"}) {
+        @mailsComponents.Tabs()
+        <div class="flex flex-col py-8 px-12">
+            <div class="flex space-x-4 items-center">
+                <h2 class="text-3xl text-gradient font-semibold">Sent Emails</h2>
+            </div>
+            <h3 class="mt-2 text-zinc-300 text-sm">View all emails sent from your domains.</h3>
+            <div class="mt-8 flow-root">
+                <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                    <div class="inline-block min-w-full py-2 align-middle px-4 sm:px-6 lg:px-8">
+                        <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 rounded-lg border border-zinc-700">
+                            <table class="min-w-full divide-y divide-zinc-700">
+                                <thead class="bg-zinc-900">
+                                    <tr>
+                                        <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white sm:pl-6">
+                                            Subject
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                            Sender
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                            Recipient
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                            Sent At
+                                        </th>
+                                        <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                                            <span class="sr-only">View</span>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-zinc-700 bg-white/2.5">
+                                    if len(emails) == 0 {
+                                        <tr>
+                                            <td class="py-4 pl-4 pr-3 text-sm font-medium text-zinc-300 sm:pl-6" colspan="5">
+                                                No emails sent yet.
+                                            </td>
+                                        </tr>
+                                    }
+                                    for _, email := range(emails) {
+                                        @emailTableItem(email)
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+templ emailTableItem(email models.Email) {
+    <tr>
+        <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-zinc-300 sm:pl-6 max-w-[100vw]">
+            
+                class="underline text-zinc-300 hover:text-zinc-100 transition-colors"
+                href={ templ.URL(util.Route(ctx, "/mails/emails/"+email.ID)) }
+            >
+                { email.Subject }
+            </a>
+        </td>
+        <td class="whitespace-nowrap px-3 py-4 text-sm text-zinc-300">
+            { email.Sender }
+        </td>
+        <td class="whitespace-nowrap px-3 py-4 text-sm text-zinc-300">
+            { email.Recipient }
+        </td>
+        <td class="whitespace-nowrap px-3 py-4 text-sm text-zinc-300">
+            { email.CreatedAt.Format(time.RFC822) }
+        </td>
+        <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+            <a href={ templ.URL(util.Route(ctx, "/mails/emails/"+email.ID)) } class="text-indigo-600 hover:text-indigo-900">
+                View<span class="sr-only">, { email.Subject }</span>
+            </a>
+        </td>
+    </tr>
+}


### PR DESCRIPTION
Added new email model, new email repo, email retrieval in smtp backend using orgID as base filter. New page for emails. Extended email search to include sender and recipient but this can be removed easily if unwanted.